### PR TITLE
fix: channel feeds should be `url` not `id`

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,17 +58,17 @@
           >.
         </text>
         <hstack>
-          <code>/rss/channel?id={parent_url}</code>
+          <code>/rss/channel?url={parent_url}</code>
           <text foreground="gray">Generate an RSS feed of casts in a channel.</text>
         </hstack>
 
         <hstack>
-          <code>/atom/channel?id={parent_url}</code>
+          <code>/atom/channel?url={parent_url}</code>
           <text foreground="gray">Generate an Atom feed of casts in a channel.</text>
         </hstack>
 
         <hstack>
-          <code>/json/channel?id={parent_url}</code>
+          <code>/json/channel?url={parent_url}</code>
           <text foreground="gray">Generate an JSON feed of casts in a channel.</text>
         </hstack>
       </vstack>


### PR DESCRIPTION
hot chocolates are mid